### PR TITLE
No Coin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -154,6 +154,7 @@ BITCOIN_CORE_H = \
   deploymentinfo.h \
   deploymentstatus.h \
   dynafed.h \
+  exchangerates.h \
   external_signer.h \
   flatfile.h \
   fs.h \
@@ -355,6 +356,7 @@ libbitcoin_node_a_SOURCES = \
   dynafed.cpp \
   dbwrapper.cpp \
   deploymentstatus.cpp \
+  exchangerates.cpp \
   flatfile.cpp \
   httprpc.cpp \
   httpserver.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -392,6 +392,7 @@ libbitcoin_node_a_SOURCES = \
   primitives/pak.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
+  rpc/exchangerates.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \
   rpc/net.cpp \

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -18,7 +18,7 @@ static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& po
     LockPoints lp;
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
     pool.addUnchecked(CTxMemPoolEntry(
-        tx, nFee, nTime, nHeight,
+        tx, nFee, ::policyAsset, nFee, nTime, nHeight,
         spendsCoinbase, sigOpCost, lp, setPeginsSpent));
 }
 

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -18,7 +18,7 @@ static void AddTx(const CTransactionRef& tx, CTxMemPool& pool) EXCLUSIVE_LOCKS_R
     unsigned int sigOpCost = 4;
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
     LockPoints lp;
-    pool.addUnchecked(CTxMemPoolEntry(tx, 1000, nTime, nHeight, spendsCoinbase, sigOpCost, lp, setPeginsSpent));
+    pool.addUnchecked(CTxMemPoolEntry(tx, 1000, ::policyAsset, 1000, nTime, nHeight, spendsCoinbase, sigOpCost, lp, setPeginsSpent));
 }
 
 struct Available {

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -13,7 +13,7 @@ static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& poo
 {
     LockPoints lp;
     std::set<std::pair<uint256, COutPoint> > setPeginsSpent;
-    pool.addUnchecked(CTxMemPoolEntry(tx, fee, /*time=*/0, /*entry_height=*/1, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp, setPeginsSpent));
+    pool.addUnchecked(CTxMemPoolEntry(tx, fee, ::policyAsset, fee, /*time=*/0, /*entry_height=*/1, /*spends_coinbase=*/false, /*sigops_cost=*/4, lp, setPeginsSpent));
 }
 
 static void RpcMempool(benchmark::Bench& bench)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1512,6 +1512,11 @@ public:
         UpdateElementsActivationParametersFromArgs(consensus, args);
 
         // END ELEMENTS fields
+
+        // SEQUENTIA fields
+        g_con_sequentiamode = true;
+
+        // END SEQUENTIA fields
     }
 
     // XXX: This is copy-and-pasted from CCustomParams; sharing it would be better, but is annoying.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1512,11 +1512,6 @@ public:
         UpdateElementsActivationParametersFromArgs(consensus, args);
 
         // END ELEMENTS fields
-
-        // SEQUENTIA fields
-        g_con_sequentiamode = true;
-
-        // END SEQUENTIA fields
     }
 
     // XXX: This is copy-and-pasted from CCustomParams; sharing it would be better, but is annoying.

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -257,11 +257,6 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
         if (!MoneyRange(fee_map)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-block-total-fee-outofrange");
         }
-        if (g_con_sequentiamode) {
-            if (fee_map.size() > 1) {
-                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-block-fees", "fees can only be paid on one currency");
-            }
-        }
     } else {
         const CAmount value_out = tx.GetValueOutMap()[CAsset()];
         if (nValueIn < value_out) {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -257,6 +257,11 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
         if (!MoneyRange(fee_map)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-block-total-fee-outofrange");
         }
+        if (g_con_sequentiamode) {
+            if (fee_map.size() > 1) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-block-fees", "fees can only be paid on one currency");
+            }
+        }
     } else {
         const CAmount value_out = tx.GetValueOutMap()[CAsset()];
         if (nValueIn < value_out) {

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -24,8 +24,8 @@ ExchangeRateMap& ExchangeRateMap::GetInstance() {
 }
 
 CAmount ExchangeRateMap::CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
-    auto it = (*this).find(asset);
-    if (it == (*this).end()) {
+    auto it = this->find(asset);
+    if (it == this->end()) {
         return 0;
     }
     auto scaledValue = it->second.scaledValue;

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -37,7 +37,7 @@ CAmount ExchangeRateMap::CalculateExchangeValue(const CAmount& amount, const CAs
     }
 }
 
-bool ExchangeRateMap::LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error) {
+bool ExchangeRateMap::LoadExchangeRatesFromJSONFile(fs::path file_path, std::string& error) {
     // Read config file
     std::ifstream ifs(file_path);
     if (!ifs.is_open()) {

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -68,7 +68,7 @@ bool ExchangeRateMap::LoadExchangeRatesFromJSONFile(fs::path file_path, std::str
         }
         CAmount exchangeRateValue;
         if (assetData.isNum()) {
-            exchangeRateValue = assetData.get_int();
+            exchangeRateValue = assetData.get_int64();
         } else if (assetData.isObject()) {
             std::map<std::string, UniValue> assetFields;
             assetData.getObjMap(assetFields);

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -57,7 +57,7 @@ bool ExchangeRateMap::LoadExchangeRatesFromJSONFile(std::string file_path, std::
     std::map<std::string, UniValue> assetMap;
     json.getObjMap(assetMap);
 
-    // Load exchange rates into global map
+    // Load exchange rates into map
     for (auto assetEntry : assetMap) {
         auto assetIdentifier = assetEntry.first;
         auto assetData = assetEntry.second;

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -8,13 +8,6 @@
 // TODO: Do we need a lock to protect this?
 std::map<CAsset, CAssetExchangeRate> g_exchange_rate_map = {};
 
-/**
- * Calculate the exchange value
- *
- * @param[out]  value        Corresponds to CTxMemPoolEntry.nFee      
- * @param[in]   amount       Corresponds to CTxMemPoolEntry.nFeeAmount
- * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
- */
 CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
     auto it = g_exchange_rate_map.find(asset); 
     if (it == g_exchange_rate_map.end()) {

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -1,0 +1,31 @@
+#include <asset.h>
+#include <consensus/amount.h>
+#include <cstdint>
+#include <exchangerates.h>
+#include <policy/policy.h>
+#include <uint256.h>
+
+// TODO: Do we need a lock to protect this?
+std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP = {{::policyAsset, EXCHANGE_RATE_SCALE}};
+
+/**
+ * Calculate the exchange value
+ *
+ * @param[out]  value        Corresponds to CTxMemPoolEntry.nFee      
+ * @param[in]   amount       Corresponds to CTxMemPoolEntry.nFeeAmount
+ * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
+ */
+CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
+    auto it = EXCHANGE_RATE_MAP.find(asset); 
+    if (it == EXCHANGE_RATE_MAP.end()) {
+        return 0;
+    }
+    auto scaledValue = it->second.scaledValue;
+    // TODO: Find cleaner alternative if possible.
+    __uint128_t value = ((__uint128_t)amount * (__uint128_t)scaledValue) / (__uint128_t)EXCHANGE_RATE_SCALE;
+    if (value > UINT64_MAX) {
+        return UINT64_MAX;
+    } else {
+        return (uint64_t) value;
+    }
+}

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -6,7 +6,7 @@
 #include <uint256.h>
 
 // TODO: Do we need a lock to protect this?
-std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP = {};
+std::map<CAsset, CAssetExchangeRate> g_exchange_rate_map = {};
 
 /**
  * Calculate the exchange value
@@ -16,13 +16,13 @@ std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP = {};
  * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
  */
 CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
-    auto it = EXCHANGE_RATE_MAP.find(asset); 
-    if (it == EXCHANGE_RATE_MAP.end()) {
+    auto it = g_exchange_rate_map.find(asset); 
+    if (it == g_exchange_rate_map.end()) {
         return 0;
     }
     auto scaledValue = it->second.scaledValue;
     // TODO: Find cleaner alternative if possible.
-    __uint128_t value = ((__uint128_t)amount * (__uint128_t)scaledValue) / (__uint128_t)EXCHANGE_RATE_SCALE;
+    __uint128_t value = ((__uint128_t)amount * (__uint128_t)scaledValue) / (__uint128_t)g_exchange_rate_scale;
     if (value > UINT64_MAX) {
         return UINT64_MAX;
     } else {

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -1,7 +1,11 @@
 #include <asset.h>
+#include <assetsdir.h>
+#include <boost/program_options.hpp>
+#include <boost/program_options/variables_map.hpp>
 #include <consensus/amount.h>
 #include <cstdint>
 #include <exchangerates.h>
+#include <fs.h>
 #include <policy/policy.h>
 #include <uint256.h>
 
@@ -21,4 +25,25 @@ CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
     } else {
         return (uint64_t) value;
     }
+}
+
+bool LoadExchangeRatesFromConfigFile(std::string file_path, std::string& error)
+{
+    // Parse config file
+    boost::program_options::variables_map options;
+    boost::program_options::options_description options_description;
+    boost::program_options::store(boost::program_options::parse_config_file(file_path.c_str(), options_description), options);
+    boost::program_options::notify(options);
+
+    // Load exchange rates into global map
+    for (auto option : options) {
+        CAsset asset = GetAssetFromString(option.first);
+        if (asset.IsNull()) {
+            error = strprintf("Unknown label and invalid asset hex: %s", asset.GetHex());
+            return false;
+        }
+        CAmount exchangeRateValue = option.second.as<int>();
+        g_exchange_rate_map[asset] = exchangeRateValue;
+    }
+    return true;
 }

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -6,7 +6,7 @@
 #include <uint256.h>
 
 // TODO: Do we need a lock to protect this?
-std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP = {{::policyAsset, EXCHANGE_RATE_SCALE}};
+std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP = {};
 
 /**
  * Calculate the exchange value

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -1,13 +1,13 @@
 #include <asset.h>
 #include <assetsdir.h>
-#include <boost/program_options.hpp>
-#include <boost/program_options/variables_map.hpp>
 #include <consensus/amount.h>
 #include <cstdint>
 #include <exchangerates.h>
 #include <fs.h>
+#include <fstream>
 #include <policy/policy.h>
 #include <uint256.h>
+#include <univalue.h>
 
 // TODO: Do we need a lock to protect this?
 std::map<CAsset, CAssetExchangeRate> g_exchange_rate_map = {};
@@ -27,22 +27,47 @@ CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
     }
 }
 
-bool LoadExchangeRatesFromConfigFile(std::string file_path, std::string& error)
+bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error)
 {
-    // Parse config file
-    boost::program_options::variables_map options;
-    boost::program_options::options_description options_description;
-    boost::program_options::store(boost::program_options::parse_config_file(file_path.c_str(), options_description), options);
-    boost::program_options::notify(options);
+    // Read config file
+    std::ifstream ifs(file_path);
+    if (!ifs.is_open()) {
+        error = strprintf("Failed to open file: %s", file_path);
+        return false;
+    }
+    std::stringstream buffer;
+    buffer << ifs.rdbuf();
+
+    // Parse as JSON
+    std::string rawJson = buffer.str();
+    UniValue json;
+    if (!json.read(rawJson)) {
+        error = "Cannot parse JSON";
+        return false;
+    }
+    std::map<std::string, UniValue> assetMap;
+    json.getObjMap(assetMap);
 
     // Load exchange rates into global map
-    for (auto option : options) {
-        CAsset asset = GetAssetFromString(option.first);
+    for (auto assetEntry : assetMap) {
+        auto assetIdentifier = assetEntry.first;
+        auto assetData = assetEntry.second;
+        CAsset asset = GetAssetFromString(assetIdentifier);
         if (asset.IsNull()) {
             error = strprintf("Unknown label and invalid asset hex: %s", asset.GetHex());
             return false;
         }
-        CAmount exchangeRateValue = option.second.as<int>();
+        CAmount exchangeRateValue;
+        if (assetData.isNum()) {
+            exchangeRateValue = assetData.get_int();
+        } else if (assetData.isObject()) {
+            std::map<std::string, UniValue> assetFields;
+            assetData.getObjMap(assetFields);
+            CAmount exchangeRateValue = assetFields["value"].get_int();
+        } else {
+            error = strprintf("Invalid value for asset %s: %d", assetIdentifier, assetData.getValStr());
+            return false;
+        }
         g_exchange_rate_map[asset] = exchangeRateValue;
     }
     return true;

--- a/src/exchangerates.cpp
+++ b/src/exchangerates.cpp
@@ -13,7 +13,7 @@
 std::map<CAsset, CAssetExchangeRate> g_exchange_rate_map = {};
 
 CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset) {
-    auto it = g_exchange_rate_map.find(asset); 
+    auto it = g_exchange_rate_map.find(asset);
     if (it == g_exchange_rate_map.end()) {
         return 0;
     }
@@ -32,7 +32,7 @@ bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error)
     // Read config file
     std::ifstream ifs(file_path);
     if (!ifs.is_open()) {
-        error = strprintf("Failed to open file: %s", file_path);
+        error = "Failed to open file";
         return false;
     }
     std::stringstream buffer;
@@ -63,7 +63,7 @@ bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error)
         } else if (assetData.isObject()) {
             std::map<std::string, UniValue> assetFields;
             assetData.getObjMap(assetFields);
-            CAmount exchangeRateValue = assetFields["value"].get_int();
+            exchangeRateValue = assetFields["value"].get_int();
         } else {
             error = strprintf("Invalid value for asset %s: %d", assetIdentifier, assetData.getValStr());
             return false;

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -4,6 +4,7 @@
 
 #include <asset.h>
 #include <consensus/amount.h>
+#include <fs.h>
 #include <policy/policy.h>
 #include <uint256.h>
 
@@ -45,7 +46,7 @@ public:
      * @param[in]   error         String reference for storing error message, if there is any.
      * @return true on success
      */
-    bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error);
+    bool LoadExchangeRatesFromJSONFile(fs::path file_path, std::string& error);
 };
 
 #endif // BITCOIN_EXCHANGERATES_H

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -39,7 +39,7 @@ CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset);
  * @param[in]   error         String reference for storing error message, if there is any.
  * @return true on success
  */
-bool LoadExchangeRatesFromConfigFile(std::string file_path, std::string& error);
+bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error);
 
 
 #endif // BITCOIN_EXCHANGERATES_H

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -18,28 +18,34 @@ public:
     CAssetExchangeRate(uint64_t amount) : scaledValue(amount) { }
 };
 
-// TODO: Do we need a lock to protect this?
-extern std::map<CAsset, CAssetExchangeRate> g_exchange_rate_map;
+class ExchangeRateMap : public std::map<CAsset, CAssetExchangeRate>
+{
+private:
+    static ExchangeRateMap* _instance;
+    const CAmount exchange_rate_scale = 1000000000L;
 
-const CAmount g_exchange_rate_scale = 1000000000L;
+    ExchangeRateMap() {}
+public:
+    static ExchangeRateMap& GetInstance();
+    void Initialize(); 
 
-/**
- * Calculate the exchange value
- *
- * @param[in]   amount       Corresponds to CTxMemPoolEntry.nFeeAmount
- * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
- * @return the value at current exchange rate. Corresponds to CTxMemPoolEntry.nFee      
- */
-CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset);
+    /**
+     * Calculate the exchange value
+     *
+     * @param[in]   amount       Corresponds to CTxMemPoolEntry.nFeeAmount
+     * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
+     * @return the value at current exchange rate. Corresponds to CTxMemPoolEntry.nFee      
+     */
+    CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset);
 
-/**
- * Populate the exchange rate map using a config file.
- *
- * @param[in]   file_path     File path to INI config file where keys are asset labels and values are exchange rates.
- * @param[in]   error         String reference for storing error message, if there is any.
- * @return true on success
- */
-bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error);
-
+    /**
+     * Populate the exchange rate map using a config file.
+     *
+     * @param[in]   file_path     File path to INI config file where keys are asset labels and values are exchange rates.
+     * @param[in]   error         String reference for storing error message, if there is any.
+     * @return true on success
+     */
+    bool LoadExchangeRatesFromJSONFile(std::string file_path, std::string& error);
+};
 
 #endif // BITCOIN_EXCHANGERATES_H

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -11,7 +11,7 @@ class CAssetExchangeRate
 {
 public:
     /** Fee rate. */
-    CAmount scaledValue; // TODO: Maybe use exatoken (10^18) rather than gigatoken (10^9).
+    CAmount scaledValue;
 
     CAssetExchangeRate() : scaledValue(0) { }
     CAssetExchangeRate(CAmount amount) : scaledValue(amount) { }

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -32,4 +32,14 @@ const CAmount g_exchange_rate_scale = 1000000000L;
  */
 CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset);
 
+/**
+ * Populate the exchange rate map using a config file.
+ *
+ * @param[in]   file_path     File path to INI config file where keys are asset labels and values are exchange rates.
+ * @param[in]   error         String reference for storing error message, if there is any.
+ * @return true on success
+ */
+bool LoadExchangeRatesFromConfigFile(std::string file_path, std::string& error);
+
+
 #endif // BITCOIN_EXCHANGERATES_H

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -26,9 +26,9 @@ const CAmount g_exchange_rate_scale = 1000000000L;
 /**
  * Calculate the exchange value
  *
- * @param[out]  value        Corresponds to CTxMemPoolEntry.nFee      
  * @param[in]   amount       Corresponds to CTxMemPoolEntry.nFeeAmount
  * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
+ * @return the value at current exchange rate. Corresponds to CTxMemPoolEntry.nFee      
  */
 CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset);
 

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -1,0 +1,35 @@
+
+#ifndef BITCOIN_EXCHANGERATES_H
+#define BITCOIN_EXCHANGERATES_H
+
+#include <asset.h>
+#include <consensus/amount.h>
+#include <policy/policy.h>
+#include <uint256.h>
+
+class CAssetExchangeRate
+{
+public:
+    /** Fee rate. */
+    CAmount scaledValue; // TODO: Maybe use exatoken (10^18) rather than gigatoken (10^9).
+
+    CAssetExchangeRate() : scaledValue(0) { }
+    CAssetExchangeRate(CAmount amount) : scaledValue(amount) { }
+    CAssetExchangeRate(uint64_t amount) : scaledValue(amount) { }
+};
+
+// TODO: Do we need a lock to protect this?
+extern std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP;
+
+const CAmount EXCHANGE_RATE_SCALE = 1000000000L;
+
+/**
+ * Calculate the exchange value
+ *
+ * @param[out]  value        Corresponds to CTxMemPoolEntry.nFee      
+ * @param[in]   amount       Corresponds to CTxMemPoolEntry.nFeeAmount
+ * @param[in]   asset        Corresponds to CTxMemPoolEntry.nFeeAsset
+ */
+CAmount CalculateExchangeValue(const CAmount& amount, const CAsset& asset);
+
+#endif // BITCOIN_EXCHANGERATES_H

--- a/src/exchangerates.h
+++ b/src/exchangerates.h
@@ -19,9 +19,9 @@ public:
 };
 
 // TODO: Do we need a lock to protect this?
-extern std::map<CAsset, CAssetExchangeRate> EXCHANGE_RATE_MAP;
+extern std::map<CAsset, CAssetExchangeRate> g_exchange_rate_map;
 
-const CAmount EXCHANGE_RATE_SCALE = 1000000000L;
+const CAmount g_exchange_rate_scale = 1000000000L;
 
 /**
  * Calculate the exchange value

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1331,11 +1331,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ELEMENTS:
     policyAsset = CAsset(uint256S(gArgs.GetArg("-feeasset", chainparams.GetConsensus().pegged_asset.GetHex())));
     if (g_con_sequentiamode) {
-        std::string file_path = gArgs.GetArg("-exchangeratesjsonfile", "");
-        if (!file_path.empty()) {
+        std::string file_path_string = gArgs.GetArg("-exchangeratesjsonfile", "");
+        if (!file_path_string.empty()) {
+            fs::path file_path = AbsPathForConfigVal(fs::PathFromString(file_path_string));
             std::string error;
             if (!ExchangeRateMap::GetInstance().LoadExchangeRatesFromJSONFile(file_path, error)) {
-                return InitError(strprintf(_("Unable to load exchange rates from JSON file %s: %s"), file_path, error));
+                return InitError(strprintf(_("Unable to load exchange rates from JSON file %s: %s"), file_path_string, error));
             };
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -641,7 +641,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-initialreissuancetokens=<n>", "The amount of reissuance tokens created in the genesis block. (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-ct_bits", strprintf("The default number of hiding bits in a rangeproof. Will be exceeded to cover amounts exceeding the maximum hiding value. (default: %d)", 52), ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-ct_exponent", strprintf("The hiding exponent. (default: %s)", 0), ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-exchangeratesjson=<file>", strprintf("Specify path to read-only configuration file with asset valuations. Relative paths will be prefixed by datadir location. (default: %s)", "exchangerates.conf"), ArgsManager::ALLOW_ANY, OptionsCategory::ELEMENTS);
+    argsman.AddArg("-exchangeratesjsonfile=<file>", strprintf("Specify path to read-only configuration file with asset valuations. Relative paths will be prefixed by datadir location. (default: %s)", "exchangerates.json"), ArgsManager::ALLOW_ANY, OptionsCategory::ELEMENTS);
 
 
 #if defined(USE_SYSCALL_SANDBOX)
@@ -1331,7 +1331,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ELEMENTS:
     policyAsset = CAsset(uint256S(gArgs.GetArg("-feeasset", chainparams.GetConsensus().pegged_asset.GetHex())));
     if (g_con_sequentiamode) {
-        std::string file_path = gArgs.GetArg("-exchangeratesjson", "");
+        std::string file_path = gArgs.GetArg("-exchangeratesjsonfile", "");
         if (!file_path.empty()) {
             std::string error;
             if (!ExchangeRateMap::GetInstance().LoadExchangeRatesFromJSONFile(file_path, error)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1334,11 +1334,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         std::string file_path = gArgs.GetArg("-exchangeratesjson", "");
         if (!file_path.empty()) {
             std::string error;
-            if (!LoadExchangeRatesFromJSONFile(file_path, error)) {
+            if (!ExchangeRateMap::GetInstance().LoadExchangeRatesFromJSONFile(file_path, error)) {
                 return InitError(strprintf(_("Unable to load exchange rates from JSON file %s: %s"), file_path, error));
             };
-        } else {
-            g_exchange_rate_map[policyAsset] = g_exchange_rate_scale;
         }
     }
     /* Start the RPC server already.  It will be started in "warmup" mode

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1329,7 +1329,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ELEMENTS:
     policyAsset = CAsset(uint256S(gArgs.GetArg("-feeasset", chainparams.GetConsensus().pegged_asset.GetHex())));
     if (g_con_sequentiamode) {
-        EXCHANGE_RATE_MAP[policyAsset] = EXCHANGE_RATE_SCALE;
+        g_exchange_rate_map[policyAsset] = g_exchange_rate_scale;
     }
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@
 #include <compat/sanity.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
+#include <exchangerates.h>
 #include <fs.h>
 #include <hash.h>
 #include <httprpc.h>
@@ -1327,7 +1328,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ELEMENTS:
     policyAsset = CAsset(uint256S(gArgs.GetArg("-feeasset", chainparams.GetConsensus().pegged_asset.GetHex())));
-
+    if (g_con_sequentiamode) {
+        EXCHANGE_RATE_MAP[policyAsset] = EXCHANGE_RATE_SCALE;
+    }
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections
      * that the server is there and will be ready later).  Warmup mode will

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1334,7 +1334,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         std::string file_path = gArgs.GetArg("-exchangeratesconf", "");
         if (!file_path.empty()) {
             std::string error;
-            if (!LoadExchangeRatesFromConfigFile(file_path, error)) {
+            if (!LoadExchangeRatesFromJSONFile(file_path, error)) {
                 return InitError(strprintf(_("Unable to load exchange rates from config file %s: %s"), file_path, error));
             };
         } else {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -641,7 +641,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-initialreissuancetokens=<n>", "The amount of reissuance tokens created in the genesis block. (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-ct_bits", strprintf("The default number of hiding bits in a rangeproof. Will be exceeded to cover amounts exceeding the maximum hiding value. (default: %d)", 52), ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-ct_exponent", strprintf("The hiding exponent. (default: %s)", 0), ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-exchangeratesconf=<file>", strprintf("Specify path to read-only configuration file with asset valuations. Relative paths will be prefixed by datadir location. (default: %s)", "exchangerates.conf"), ArgsManager::ALLOW_ANY, OptionsCategory::ELEMENTS);
+    argsman.AddArg("-exchangeratesjson=<file>", strprintf("Specify path to read-only configuration file with asset valuations. Relative paths will be prefixed by datadir location. (default: %s)", "exchangerates.conf"), ArgsManager::ALLOW_ANY, OptionsCategory::ELEMENTS);
 
 
 #if defined(USE_SYSCALL_SANDBOX)
@@ -1331,11 +1331,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ELEMENTS:
     policyAsset = CAsset(uint256S(gArgs.GetArg("-feeasset", chainparams.GetConsensus().pegged_asset.GetHex())));
     if (g_con_sequentiamode) {
-        std::string file_path = gArgs.GetArg("-exchangeratesconf", "");
+        std::string file_path = gArgs.GetArg("-exchangeratesjson", "");
         if (!file_path.empty()) {
             std::string error;
             if (!LoadExchangeRatesFromJSONFile(file_path, error)) {
-                return InitError(strprintf(_("Unable to load exchange rates from config file %s: %s"), file_path, error));
+                return InitError(strprintf(_("Unable to load exchange rates from JSON file %s: %s"), file_path, error));
             };
         } else {
             g_exchange_rate_map[policyAsset] = g_exchange_rate_scale;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -612,7 +612,7 @@ public:
         if (!m_node.mempool) return true;
         LockPoints lp;
         std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
-        CTxMemPoolEntry entry(tx, 0, 0, 0, false, 0, lp, setPeginsSpent);
+        CTxMemPoolEntry entry(tx, 0, ::policyAsset, 0, 0, 0, false, 0, lp, setPeginsSpent);
         CTxMemPool::setEntries ancestors;
         auto limit_ancestor_count = gArgs.GetIntArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
         auto limit_ancestor_size = gArgs.GetIntArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -315,6 +315,8 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     nBlockWeight += iter->GetTxWeight();
     ++nBlockTx;
     nBlockSigOpsCost += iter->GetSigOpCost();
+    // TODO: Make sure that this value stays within MoneyRange to prevent overflow exploits. 
+    // Or better yet, make sure that asset tokens are kept under the MAX_MONEY limit.
     feeMap[iter->GetFeeAsset()] += iter->GetFee();
     inBlock.insert(iter);
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -192,12 +192,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;
+    coinbaseTx.vin.resize(1);
+    coinbaseTx.vin[0].prevout.SetNull();
     if (g_con_sequentiamode && feeMap.size() > 0) {
-        coinbaseTx.vin.resize(feeMap.size());
         coinbaseTx.vout.resize(feeMap.size());
         int index = 0;
         for (auto fee : feeMap) {
-            coinbaseTx.vin[index].prevout.SetNull();
             coinbaseTx.vout[index].scriptPubKey = scriptPubKeyIn;
             coinbaseTx.vout[index].nAsset = fee.first;
             coinbaseTx.vout[index].nValue = fee.second;
@@ -217,8 +217,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             index++;
         }
     } else {
-        coinbaseTx.vin.resize(1);
-        coinbaseTx.vin[0].prevout.SetNull();
         coinbaseTx.vout.resize(1);
         coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
         coinbaseTx.vout[0].nAsset = policyAsset;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -192,7 +192,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;
-    if (feeMap.size() > 0) {
+    if (g_con_sequentiamode && feeMap.size() > 0) {
         coinbaseTx.vin.resize(feeMap.size());
         coinbaseTx.vout.resize(feeMap.size());
         int index = 0;
@@ -200,16 +200,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             coinbaseTx.vin[index].prevout.SetNull();
             coinbaseTx.vout[index].scriptPubKey = scriptPubKeyIn;
             coinbaseTx.vout[index].nAsset = fee.first;
-            coinbaseTx.vout[index].nValue = fee.second + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
-            if (g_con_elementsmode) {
-                if(chainparams.GetConsensus().subsidy_asset != policyAsset) {
-                    // Only claim the subsidy if it's the same as the policy asset.
-                    coinbaseTx.vout[index].nValue = fee.second;
-                }
-                // 0-value outputs must be unspendable
-                if (coinbaseTx.vout[index].nValue.GetAmount() == 0) {
-                    coinbaseTx.vout[index].scriptPubKey = CScript() << OP_RETURN;
-                }
+            coinbaseTx.vout[index].nValue = fee.second;
+            if (coinbaseTx.vout[index].nValue.GetAmount() == 0) {
+                coinbaseTx.vout[index].scriptPubKey = CScript() << OP_RETURN;
             }
             coinbaseTx.vin[index].scriptSig = CScript() << nHeight << OP_0;
             // Non-consensus commitment output before finishing coinbase transaction

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -151,6 +151,9 @@ private:
     const CTxMemPool& m_mempool;
     CChainState& m_chainstate;
 
+    // SEQUENTIA:
+    CAmountMap feeMap;
+
 public:
     struct Options {
         Options();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -13,6 +13,7 @@
 #include <assert.h>
 
 bool g_con_elementsmode = false;
+// TODO: Default to false and override using new chain params class for Sequentia
 bool g_con_sequentiamode = true;
 
 const int32_t CTransaction::CURRENT_VERSION = 2;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -13,7 +13,7 @@
 #include <assert.h>
 
 bool g_con_elementsmode = false;
-bool g_con_sequentiamode = false;
+bool g_con_sequentiamode = true;
 
 const int32_t CTransaction::CURRENT_VERSION = 2;
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -13,6 +13,7 @@
 #include <assert.h>
 
 bool g_con_elementsmode = false;
+bool g_con_sequentiamode = false;
 
 const int32_t CTransaction::CURRENT_VERSION = 2;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -28,6 +28,9 @@ static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 // Globals to avoid circular dependencies.
 extern bool g_con_elementsmode;
 
+// SEQUENTIA:
+extern bool g_con_sequentiamode;
+
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
 {

--- a/src/rpc/exchangerates.cpp
+++ b/src/rpc/exchangerates.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rpc/server_util.h>
+
+#include <exchangerates.h>
+#include <rpc/register.h>
+#include <rpc/server.h>
+#include <rpc/util.h>
+#include <assetsdir.h>
+
+using node::NodeContext;
+
+static RPCHelpMan getfeeexchangerates()
+{
+    return RPCHelpMan{"getfeeexchangerates",
+                "\nReturns a map of assets with their current exchange rates, for use in valuating fee payments.\n",
+                {},
+                RPCResult{
+                    RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "rates", "A table mapping asset tag to rate of exchange for one unit of the asset in terms of the reference fee asset."},
+                    }},
+                RPCExamples{
+                    HelpExampleCli("getfeeexchangerates", "")
+                  + HelpExampleRpc("getfeeexchangerates", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    UniValue response = UniValue{UniValue::VOBJ};
+    UniValue rates = UniValue{UniValue::VOBJ};
+    for (auto rate: EXCHANGE_RATE_MAP) {
+        rates.pushKV(rate.first.GetHex(), rate.second.scaledValue);
+    }
+    response.pushKV("rates", rates);
+    return response;
+},
+    };
+}
+
+static RPCHelpMan setfeeexchangerates()
+{
+    return RPCHelpMan{"setfeeexchangerates",
+                "\nPrivileged call to set the set of accepted assets for paying fees, and the exchange rate for each of these assets.\n",
+                {
+                    {"rates", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO, "A table mapping asset tag to rate of exchange for one unit of the asset in terms of the reference fee asset.",
+                        {
+                            {"asset", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The asset hex is the key, the numeric amount (can be string) is the value"},
+                        }
+                    },
+                    {"expiry_timestamp", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A expiry timestamp (unix timestamp UTC) until which to accept those rates."},
+                    {"reference_asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A reference asset tag."},
+                },
+                RPCResult{RPCResult::Type::NONE, "", ""},
+                RPCExamples{
+                    HelpExampleCli("setfeeexchangerates", "")
+                  + HelpExampleRpc("setfeeexchangerates", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    UniValue ratesField = request.params[0].get_obj();
+    std::map<std::string, UniValue> rates;
+    ratesField.getObjMap(rates);
+    for (auto rate : rates) {
+        CAsset asset = GetAssetFromString(rate.first);
+        if (asset.IsNull()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Unknown label and invalid asset hex: %s", asset.GetHex()));
+        }
+        uint64_t rateValue = rate.second.get_int();
+        EXCHANGE_RATE_MAP[asset] = CAssetExchangeRate(rateValue);
+    } 
+    return NullUniValue;
+},
+    };
+}
+
+void RegisterExchangeRatesRPCCommands(CRPCTable &t)
+{
+// clang-format off
+
+static const CRPCCommand commands[] =
+{ //  category              actor (function)
+  //  --------------------- ------------------------
+    { "exchangerates",      &getfeeexchangerates,                  },
+    { "exchangerates",      &setfeeexchangerates,                  },
+};
+// clang-format on
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
+    }
+}

--- a/src/rpc/exchangerates.cpp
+++ b/src/rpc/exchangerates.cpp
@@ -32,7 +32,7 @@ static RPCHelpMan getfeeexchangerates()
 {
     UniValue response = UniValue{UniValue::VOBJ};
     UniValue rates = UniValue{UniValue::VOBJ};
-    for (auto rate: EXCHANGE_RATE_MAP) {
+    for (auto rate: g_exchange_rate_map) {
         rates.pushKV(rate.first.GetHex(), rate.second.scaledValue);
     }
     response.pushKV("rates", rates);
@@ -69,9 +69,9 @@ static RPCHelpMan setfeeexchangerates()
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Unknown label and invalid asset hex: %s", asset.GetHex()));
         }
         CAmount newRateValue = rate.second.get_int();
-        CAmount currentRateValue = EXCHANGE_RATE_MAP[asset].scaledValue;
+        CAmount currentRateValue = g_exchange_rate_map[asset].scaledValue;
         if (newRateValue != currentRateValue) {
-            EXCHANGE_RATE_MAP[asset] = newRateValue;
+            g_exchange_rate_map[asset] = newRateValue;
             isUpdated = true;
         }
     } 

--- a/src/rpc/exchangerates.cpp
+++ b/src/rpc/exchangerates.cpp
@@ -49,9 +49,7 @@ static RPCHelpMan setfeeexchangerates()
                             {"asset", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The asset hex is the key, the numeric amount (can be string) is the value"},
                         }
                     },
-                    {"expiry_timestamp", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A expiry timestamp (unix timestamp UTC) until which to accept those rates."},
-                    {"reference_asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A reference asset tag."},
-                },
+               },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
                     HelpExampleCli("setfeeexchangerates", "")

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -137,7 +137,7 @@ static std::vector<RPCArg> CreateTxDoc()
                 {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
                     {
                         {"fee", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The key is \"fee\", the value the fee output you want to add."},
-                        {"asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The asset tag for the fee if it is not the main chain asset"},
+                        {"fee_asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The asset tag for the fee if it is not the main chain asset"},
                     },
                     },
             },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -137,6 +137,7 @@ static std::vector<RPCArg> CreateTxDoc()
                 {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
                     {
                         {"fee", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The key is \"fee\", the value the fee output you want to add."},
+                        {"asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The asset tag for the fee if it is not the main chain asset"},
                     },
                     },
             },

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -324,8 +324,8 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 out.nValue = nAmount;
                 
                 // SEQUENTIA: Allow fees in any asset
-                if (g_con_sequentiamode && output.exists("asset")) {
-                    out.nAsset = CAsset(ParseHashO(output, "asset"));
+                if (g_con_sequentiamode && output.exists("fee_asset")) {
+                    out.nAsset = CAsset(ParseHashO(output, "fee_asset"));
                 }
                 out.scriptPubKey = CScript();
                 is_fee = true;

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -324,10 +324,8 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 out.nValue = nAmount;
                 
                 // SEQUENTIA: Allow fees in any asset
-                if (g_con_sequentiamode) {
-                    if (output.exists("asset")) {
-                        out.nAsset = CAsset(ParseHashO(output, "asset"));
-                    }
+                if (g_con_sequentiamode && output.exists("asset")) {
+                    out.nAsset = CAsset(ParseHashO(output, "asset"));
                 }
                 out.scriptPubKey = CScript();
                 is_fee = true;

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -322,9 +322,12 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 // ELEMENTS: explicit fee outputs
                 CAmount nAmount = AmountFromValue(output[name_]);
                 out.nValue = nAmount;
+                
                 // SEQUENTIA: Allow fees in any asset
-                if (output.exists("asset")) {
-                    out.nAsset = CAsset(ParseHashO(output, "asset"));
+                if (g_con_sequentiamode) {
+                    if (output.exists("asset")) {
+                        out.nAsset = CAsset(ParseHashO(output, "asset"));
+                    }
                 }
                 out.scriptPubKey = CScript();
                 is_fee = true;

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -322,6 +322,10 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 // ELEMENTS: explicit fee outputs
                 CAmount nAmount = AmountFromValue(output[name_]);
                 out.nValue = nAmount;
+                // SEQUENTIA: Allow fees in any asset
+                if (output.exists("asset")) {
+                    out.nAsset = CAsset(ParseHashO(output, "asset"));
+                }
                 out.scriptPubKey = CScript();
                 is_fee = true;
                 break;

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -21,6 +21,8 @@ void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
 /** Register raw transaction RPC commands */
 void RegisterSignerRPCCommands(CRPCTable &tableRPC);
+/** Register exchange rates RPC commands */
+void RegisterExchangeRatesRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
@@ -32,6 +34,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 #ifdef ENABLE_EXTERNAL_SIGNER
     RegisterSignerRPCCommands(t);
 #endif // ENABLE_EXTERNAL_SIGNER
+    RegisterExchangeRatesRPCCommands(t);
 }
 
 #endif // BITCOIN_RPC_REGISTER_H

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1239,7 +1239,9 @@ UniValue AmountMapToUniv(const CAmountMap& balanceOrig, std::string strasset)
 {
     // Make sure the policyAsset is always present in the balance map.
     CAmountMap balance = balanceOrig;
-    balance[::policyAsset] += 0;
+    if (!g_con_sequentiamode) {
+        balance[::policyAsset] += 0;
+    }
 
     // If we don't do assets or a specific asset is given, we filter out once asset.
     if (!g_con_elementsmode || strasset != "") {

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -471,7 +471,7 @@ CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzzed_data_provider, 
     const bool spends_coinbase = fuzzed_data_provider.ConsumeBool();
     const unsigned int sig_op_cost = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, MAX_BLOCK_SIGOPS_COST);
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
-    return CTxMemPoolEntry{MakeTransactionRef(tx), fee, time, entry_height, spends_coinbase, sig_op_cost, {}, setPeginsSpent};
+    return CTxMemPoolEntry{MakeTransactionRef(tx), fee, ::policyAsset, fee, time, entry_height, spends_coinbase, sig_op_cost, {}, setPeginsSpent};
 }
 
 bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -386,7 +386,7 @@ CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction& tx) co
 
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransactionRef& tx) const
 {
-    return CTxMemPoolEntry(tx, nFee, nTime, nHeight,
+    return CTxMemPoolEntry(tx, nFee, ::policyAsset, nFee, nTime, nHeight,
                            spendsCoinbase, sigOpCost, lp, setPeginsSpent);
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -84,26 +84,6 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
     return true;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
-                                 int64_t time, unsigned int entry_height,
-                                 bool spends_coinbase, int64_t sigops_cost, LockPoints lp,
-                                 const std::set<std::pair<uint256, COutPoint>>& _setPeginsSpent)
-    : tx{tx},
-      nFee{fee},
-      nTxWeight(GetTransactionWeight(*tx)),
-      nUsageSize{RecursiveDynamicUsage(tx)},
-      nTime{time},
-      entryHeight{entry_height},
-      spendsCoinbase{spends_coinbase},
-      sigOpCost{sigops_cost},
-      lockPoints{lp},
-      nSizeWithDescendants{GetTxSize()},
-      nModFeesWithDescendants{nFee},
-      nSizeWithAncestors{GetTxSize()},
-      nModFeesWithAncestors{nFee},
-      nSigOpCostWithAncestors{sigOpCost},
-      setPeginsSpent(_setPeginsSpent) {}
-
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset, CAmount feeAmount,
                                  int64_t time, unsigned int entry_height,
                                  bool spends_coinbase, int64_t sigops_cost, LockPoints lp,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -104,6 +104,27 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
       nSigOpCostWithAncestors{sigOpCost},
       setPeginsSpent(_setPeginsSpent) {}
 
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset,
+                                 int64_t time, unsigned int entry_height,
+                                 bool spends_coinbase, int64_t sigops_cost, LockPoints lp,
+                                 const std::set<std::pair<uint256, COutPoint>>& _setPeginsSpent)
+    : tx{tx},
+      nFee{fee},
+      feeAsset{feeAsset},
+      nTxWeight(GetTransactionWeight(*tx)),
+      nUsageSize{RecursiveDynamicUsage(tx)},
+      nTime{time},
+      entryHeight{entry_height},
+      spendsCoinbase{spends_coinbase},
+      sigOpCost{sigops_cost},
+      lockPoints{lp},
+      nSizeWithDescendants{GetTxSize()},
+      nModFeesWithDescendants{nFee},
+      nSizeWithAncestors{GetTxSize()},
+      nModFeesWithAncestors{nFee},
+      nSigOpCostWithAncestors{sigOpCost},
+      setPeginsSpent(_setPeginsSpent) {}
+
 void CTxMemPoolEntry::UpdateFeeDelta(int64_t newFeeDelta)
 {
     nModFeesWithDescendants += newFeeDelta - feeDelta;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -104,13 +104,14 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
       nSigOpCostWithAncestors{sigOpCost},
       setPeginsSpent(_setPeginsSpent) {}
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset,
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset, CAmount feeAmount,
                                  int64_t time, unsigned int entry_height,
                                  bool spends_coinbase, int64_t sigops_cost, LockPoints lp,
                                  const std::set<std::pair<uint256, COutPoint>>& _setPeginsSpent)
     : tx{tx},
       nFee{fee},
-      feeAsset{feeAsset},
+      nFeeAsset{feeAsset},
+      nFeeAmount{feeAmount},
       nTxWeight(GetTransactionWeight(*tx)),
       nUsageSize{RecursiveDynamicUsage(tx)},
       nTime{time},

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1070,9 +1070,10 @@ void CTxMemPool::RecomputeFees()
 {
     {
         LOCK(cs);
+        ExchangeRateMap exchangeRateMap = ExchangeRateMap::GetInstance();
         for (CTxMemPoolEntry tx : mapTx) {
             txiter it = mapTx.find(tx.GetTx().GetHash());
-            CAmount newFee = CalculateExchangeValue(tx.GetFeeAmount(), tx.GetFeeAsset());
+            CAmount newFee = exchangeRateMap.CalculateExchangeValue(tx.GetFeeAmount(), tx.GetFeeAsset());
             CAmount feeDelta = newFee - tx.GetFee();
             if (feeDelta != 0) {
                 mapTx.modify(it, update_fee(newFee));

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -95,9 +95,9 @@ private:
     const CTransactionRef tx;
     mutable Parents m_parents;
     mutable Children m_children;
-    CAmount nFee;                   //!< Value in reference unit. Cached to avoid expensive parent-transaction lookups.
-    const CAsset nFeeAsset;         //!< SEQUENTIA: Asset used for fee payment.
-    const CAmount nFeeAmount;       //!< SEQUENTIA: Amount in the transaction. 
+    CAmount nFee;                   //!< Value in reference unit, computed using configured exchange rates. It is not a `const` because it needs to be updated whenever exchange rates change.
+    const CAsset nFeeAsset;         //!< SEQUENTIA: The asset used for fee payment.
+    const CAmount nFeeAmount;       //!< SEQUENTIA: The amount of nFeeAsset used for fee payment.
     const size_t nTxWeight;         //!< ... and avoid recomputing tx weight (also used for GetTxSize())
     const size_t nUsageSize;        //!< ... and total memory usage
     const int64_t nTime;            //!< Local time when entering the mempool

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -148,6 +148,8 @@ public:
     // Updates the fee delta used for mining priority score, and the
     // modified fees with descendants.
     void UpdateFeeDelta(int64_t feeDelta);
+    // Updates the base fee and the modified fees with ancestors and descendants.
+    void UpdateFee(const CAmount fee);
     // Update the LockPoints after a reorg
     void UpdateLockPoints(const LockPoints& lp);
 
@@ -627,7 +629,10 @@ public:
     /** Affect CreateNewBlock prioritisation of transactions */
     void PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
     void ApplyDelta(const uint256& hash, CAmount &nFeeDelta) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void ClearPrioritisation(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void ClearPrioritisation(const uint256& hash);
+
+    /** Recompute valuation of all transaction fees, called whenever exchange rates have been updated. */
+    void RecomputeFees();
 
     /** Get the transaction in the pool that spends the same prevout */
     const CTransaction* GetConflictTx(const COutPoint& prevout) const EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -121,15 +121,17 @@ private:
     int64_t nSigOpCostWithAncestors;
 
 public:
-    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
-                    int64_t time, unsigned int entry_height,
-                    bool spends_coinbase,
-                    int64_t sigops_cost, LockPoints lp,
-                    const std::set<std::pair<uint256, COutPoint>>& setPeginsSpent);
+    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, const CAsset feeAsset, const CAmount feeAmount,
+                int64_t time, unsigned int entry_height,
+                bool spends_coinbase,
+                int64_t sigops_cost, LockPoints lp,
+                const std::set<std::pair<uint256, COutPoint>>& setPeginsSpent);
 
     const CTransaction& GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }
     const CAmount& GetFee() const { return nFee; }
+    const CAsset& GetFeeAsset() const { return nFeeAsset; }
+    const CAmount& GetFeeAmount() const { return nFeeAmount; }
     size_t GetTxSize() const;
     size_t GetTxWeight() const { return nTxWeight; }
     std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
@@ -171,15 +173,6 @@ public:
 
     // ELEMENTS:
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
-
-    // SEQUENTIA:
-    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset, CAmount feeAmount,
-            int64_t time, unsigned int entry_height,
-            bool spends_coinbase,
-            int64_t sigops_cost, LockPoints lp,
-            const std::set<std::pair<uint256, COutPoint>>& setPeginsSpent);
-
-    const CAsset& GetFeeAsset() const { return nFeeAsset; }
 };
 
 // extracts a transaction hash from CTxMemPoolEntry or CTransactionRef

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -95,7 +95,9 @@ private:
     const CTransactionRef tx;
     mutable Parents m_parents;
     mutable Children m_children;
-    const CAmount nFee;             //!< Cached to avoid expensive parent-transaction lookups
+    CAmount nFee;                   //!< Value in reference unit. Cached to avoid expensive parent-transaction lookups.
+    const CAsset nFeeAsset;         //!< SEQUENTIA: Asset used for fee payment.
+    const CAmount nFeeAmount;       //!< SEQUENTIA: Amount in the transaction. 
     const size_t nTxWeight;         //!< ... and avoid recomputing tx weight (also used for GetTxSize())
     const size_t nUsageSize;        //!< ... and total memory usage
     const int64_t nTime;            //!< Local time when entering the mempool
@@ -117,9 +119,6 @@ private:
     uint64_t nSizeWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
-
-    // SEQUENTIA:
-    const CAsset feeAsset;
 
 public:
     CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
@@ -174,13 +173,13 @@ public:
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
 
     // SEQUENTIA:
-    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset,
+    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset, CAmount feeAmount,
             int64_t time, unsigned int entry_height,
             bool spends_coinbase,
             int64_t sigops_cost, LockPoints lp,
             const std::set<std::pair<uint256, COutPoint>>& setPeginsSpent);
 
-    const CAsset& GetFeeAsset() const { return feeAsset; }
+    const CAsset& GetFeeAsset() const { return nFeeAsset; }
 };
 
 // extracts a transaction hash from CTxMemPoolEntry or CTransactionRef

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -118,6 +118,9 @@ private:
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 
+    // SEQUENTIA:
+    const CAsset feeAsset;
+
 public:
     CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
                     int64_t time, unsigned int entry_height,
@@ -169,6 +172,15 @@ public:
 
     // ELEMENTS:
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
+
+    // SEQUENTIA:
+    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset,
+            int64_t time, unsigned int entry_height,
+            bool spends_coinbase,
+            int64_t sigops_cost, LockPoints lp,
+            const std::set<std::pair<uint256, COutPoint>>& setPeginsSpent);
+
+    const CAsset& GetFeeAsset() const { return feeAsset; }
 };
 
 // extracts a transaction hash from CTxMemPoolEntry or CTransactionRef

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -911,7 +911,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         }
     }
 
-    CAmount currentFeeValuation = CalculateExchangeValue(ws.m_base_fees, feeAsset);
+    CAmount currentFeeValuation = ExchangeRateMap::GetInstance().CalculateExchangeValue(ws.m_base_fees, feeAsset);
     entry.reset(new CTxMemPoolEntry(ptx, currentFeeValuation, feeAsset, ws.m_base_fees, nAcceptTime, m_active_chainstate.m_chain.Height(),
             fSpendsCoinbase, nSigOpsCost, lp, setPeginsSpent));
     ws.m_vsize = entry->GetTxSize();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -846,8 +846,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     assert(m_active_chainstate.m_blockman.LookupBlockIndex(m_view.GetBestBlock()) == m_active_chainstate.m_chain.Tip());
 
-
-     // Only accept BIP68 sequence locked transactions that can be mined in the next
+    // Only accept BIP68 sequence locked transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.
     // Pass in m_view which has all of the relevant inputs cached. Note that, since m_view's

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -17,6 +17,7 @@
 #include <consensus/validation.h>
 #include <cuckoocache.h>
 #include <deploymentstatus.h>
+#include <exchangerates.h>
 #include <flatfile.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
@@ -913,7 +914,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         }
     }
 
-    entry.reset(new CTxMemPoolEntry(ptx, ws.m_base_fees, feeAsset, nAcceptTime, m_active_chainstate.m_chain.Height(),
+    CAmount currentFeeValuation = CalculateExchangeValue(ws.m_base_fees, feeAsset);
+    entry.reset(new CTxMemPoolEntry(ptx, currentFeeValuation, feeAsset, ws.m_base_fees, nAcceptTime, m_active_chainstate.m_chain.Height(),
             fSpendsCoinbase, nSigOpsCost, lp, setPeginsSpent));
     ws.m_vsize = entry->GetTxSize();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -883,14 +883,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_WITNESS_MUTATED, "bad-witness-nonstandard");
 
     int64_t nSigOpsCost = GetTransactionSigOpCost(tx, m_view, STANDARD_SCRIPT_VERIFY_FLAGS);
-
+    
     CAsset feeAsset;
     if (g_con_sequentiamode) {
-        for (auto fee : fee_map) {
-            feeAsset = fee.first;
-        }
+        feeAsset = fee_map.begin()->first;
     } else {
-        // We only consider policyAsset
         feeAsset = policyAsset;
     }
     ws.m_base_fees = fee_map[feeAsset];

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -65,7 +65,7 @@ public:
     int m_min_depth = DEFAULT_MIN_DEPTH;
     //! Maximum chain depth value for coin availability
     int m_max_depth = DEFAULT_MAX_DEPTH;
-    //! SEQUENTIA: Override the protocol's policyAsset for fee payment
+    //! SEQUENTIA: Enables overriding of the protocol's policyAsset for fee payment
     CAsset m_fee_asset = policyAsset;
 
     CCoinControl();

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -66,7 +66,7 @@ public:
     //! Maximum chain depth value for coin availability
     int m_max_depth = DEFAULT_MAX_DEPTH;
     //! SEQUENTIA: Override the protocol's policyAsset for fee payment
-    CAsset m_fee_asset = ::policyAsset;
+    CAsset m_fee_asset = policyAsset;
 
     CCoinControl();
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -10,6 +10,7 @@
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
+#include <policy/policy.h>
 #include <primitives/bitcoin/transaction.h>
 #include <primitives/transaction.h>
 #include <script/keyorigin.h>
@@ -64,6 +65,8 @@ public:
     int m_min_depth = DEFAULT_MIN_DEPTH;
     //! Maximum chain depth value for coin availability
     int m_max_depth = DEFAULT_MAX_DEPTH;
+    //! SEQUENTIA: Override the protocol's policyAsset for fee payment
+    CAsset m_fee_asset = ::policyAsset;
 
     CCoinControl();
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -81,7 +81,10 @@ static const size_t TOTAL_TRIES = 100000;
 
 std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change)
 {
-    CAmountMap map_target{{ ::policyAsset, selection_target}};
+    if (utxo_pool.empty()) {
+        return std::nullopt;
+    }
+    CAmountMap map_target{{utxo_pool.at(0).fee_asset, selection_target}};
     SelectionResult result(map_target);
     CAmount curr_value = 0;
 
@@ -187,7 +190,10 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
 
 std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value)
 {
-    CAmountMap map_target{{ ::policyAsset, target_value}};
+    if (utxo_pool.empty()) {
+        return std::nullopt;
+    }
+    CAmountMap map_target{{utxo_pool.at(0).fee_asset, target_value}};
     SelectionResult result(map_target);
 
     std::vector<size_t> indexes;
@@ -255,7 +261,7 @@ static void ApproximateBestSubset(const std::vector<OutputGroup>& groups, const 
 }
 
 // ELEMENTS:
-std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmountMap& mapTargetValue)
+std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmountMap& mapTargetValue, const CAsset& feeAsset)
 {
     SelectionResult result(mapTargetValue);
 
@@ -270,7 +276,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
         if (it->second == 0) {
             continue;
         }
-        if (it->first == ::policyAsset) {
+        if (it->first == feeAsset) {
             continue;
         }
 
@@ -319,7 +325,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
     NOTE:
     CInputCoin::effective_value is negative for non-policy assets, so the sum non_policy_effective_value is negative. Therefore, it is subtracted in order to increase policy_target by the fees required.
     */
-    CAmount policy_target = mapTargetValue.at(::policyAsset) - non_policy_effective_value;
+    CAmount policy_target = mapTargetValue.at(feeAsset) - non_policy_effective_value;
     if (policy_target > 0) {
         inner_groups.clear();
 
@@ -335,7 +341,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
                     break;
                 }
 
-                if (c.asset != ::policyAsset) {
+                if (c.asset != feeAsset) {
                     add = false;
                     break;
                 }
@@ -351,10 +357,10 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
             return std::nullopt;
         }
 
-        if (auto inner_result = KnapsackSolver(inner_groups, policy_target, ::policyAsset)) {
+        if (auto inner_result = KnapsackSolver(inner_groups, policy_target, feeAsset)) {
             result.AddInput(*inner_result);
         } else {
-            LogPrint(BCLog::SELECTCOINS, "Not enough funds to create target %d for policy asset %s\n", policy_target, ::policyAsset.GetHex());
+            LogPrint(BCLog::SELECTCOINS, "Not enough funds to create target %d for fee asset %s\n", policy_target, feeAsset.GetHex());
             return std::nullopt;
         }
     }
@@ -445,8 +451,8 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
 void OutputGroup::Insert(const CInputCoin& output, int depth, bool from_me, size_t ancestors, size_t descendants, bool positive_only) {
     // Compute the effective value first
     const CAmount coin_fee = output.m_input_bytes < 0 ? 0 : m_effective_feerate.GetFee(output.m_input_bytes);
-    // ELEMENTS: "effective value" only comes from the policy asset
-    const CAmount ev = output.value * (output.asset == ::policyAsset) - coin_fee;
+    // ELEMENTS: "effective value" only comes from the fee asset
+    const CAmount ev = output.value * (output.asset == fee_asset) - coin_fee;
 
     // Filter for positive only here before adding the coin
     if (positive_only && ev <= 0) return;
@@ -486,7 +492,7 @@ CAmount OutputGroup::GetSelectionAmount() const
 {
     // ELEMENTS: non-policy assets always use `m_value`. Their (negative)
     //  `effective_value` will be added to the target for the policy asset
-    if (!m_outputs.empty() && m_outputs[0].asset != ::policyAsset) {
+    if (!m_outputs.empty() && m_outputs[0].asset != fee_asset) {
         return m_value;
     }
     return m_subtract_fee_outputs ? m_value : effective_value;

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -126,6 +126,8 @@ struct CoinSelectionParams
      * associated with the same address. This helps reduce privacy leaks resulting from address
      * reuse. Dust outputs are not eligible to be added to output groups and thus not considered. */
     bool m_avoid_partial_spends = false;
+    /** The asset with which to pay fees. */
+    CAsset m_fee_asset;
 
     CoinSelectionParams(size_t change_output_size, size_t change_spend_size, CFeeRate effective_feerate,
                         CFeeRate long_term_feerate, CFeeRate discard_feerate, size_t tx_noinputs_size, bool avoid_partial) :
@@ -184,6 +186,8 @@ struct OutputGroup
     CAmount effective_value{0};
     /** The fee to spend these UTXOs at the effective feerate. */
     CAmount fee{0};
+    /** The fee to spend these UTXOs at the effective feerate. */
+    CAsset fee_asset;
     /** The target feerate of the transaction we're trying to build. */
     CFeeRate m_effective_feerate{0};
     /** The fee to spend these UTXOs at the long term feerate. */
@@ -200,7 +204,8 @@ struct OutputGroup
     OutputGroup(const CoinSelectionParams& params) :
         m_effective_feerate(params.m_effective_feerate),
         m_long_term_feerate(params.m_long_term_feerate),
-        m_subtract_fee_outputs(params.m_subtract_fee_outputs)
+        m_subtract_fee_outputs(params.m_subtract_fee_outputs),
+        fee_asset(params.m_fee_asset)
     {}
 
     void Insert(const CInputCoin& output, int depth, bool from_me, size_t ancestors, size_t descendants, bool positive_only);
@@ -282,7 +287,7 @@ std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, 
 
 // ELEMENTS:
 // Knapsack that delegates for every asset individually.
-std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmountMap& mapTargetValue);
+std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmountMap& mapTargetValue, const CAsset& asset);
 
 // Get coin selection waste for a map of asset->amount.
 [[nodiscard]] CAmount GetSelectionWaste(const std::set<CInputCoin>& inputs, CAmount change_cost, const CAmountMap& target_map, bool use_effective_value);

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -251,7 +251,7 @@ CAmountMap CachedTxGetAvailableCredit(const CWallet& wallet, const CWalletTx& wt
 
 void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                   std::list<COutputEntry>& listReceived,
-                  std::list<COutputEntry>& listSent, CAmount& nFee, const isminefilter& filter)
+                  std::list<COutputEntry>& listSent, CAmount& nFee, CAsset& nFeeAsset, const isminefilter& filter)
 {
     nFee = 0;
     listReceived.clear();
@@ -261,7 +261,9 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
     CAmountMap mapDebit = CachedTxGetDebit(wallet, wtx, filter);
     if (mapDebit > CAmountMap()) // debit>0 means we signed/sent this transaction
     {
-        nFee = -GetFeeMap(*wtx.tx)[::policyAsset];
+        CAmountMap feeMap = GetFeeMap(*wtx.tx);
+        nFeeAsset = g_con_sequentiamode ? feeMap.begin()->first : ::policyAsset;
+        nFee = -feeMap[nFeeAsset];
     }
 
     LOCK(wallet.cs_wallet);

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -54,7 +54,7 @@ struct COutputEntry
 void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                         std::list<COutputEntry>& listReceived,
                         std::list<COutputEntry>& listSent,
-                        CAmount& nFee, const isminefilter& filter);
+                        CAmount& nFee, CAsset& nFeeAsset, const isminefilter& filter);
 bool CachedTxIsFromMe(const CWallet& wallet, const CWalletTx& wtx, const isminefilter& filter);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<uint256>& trusted_parents) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -490,7 +490,7 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
                 {"locktime", UniValueType(UniValue::VNUM)},
                 {"fee_rate", UniValueType()}, // will be checked by AmountFromValue() in SetFeeEstimateMode()
                 {"feeRate", UniValueType()}, // will be checked by AmountFromValue() below
-                {"feeAsset", UniValueType(UniValue::VSTR)},
+                {"fee_asset", UniValueType(UniValue::VSTR)},
                 {"psbt", UniValueType(UniValue::VBOOL)},
                 {"solving_data", UniValueType(UniValue::VOBJ)},
                 {"subtractFeeFromOutputs", UniValueType(UniValue::VARR)},
@@ -596,8 +596,8 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
         coinControl.fAllowWatchOnly = ParseIncludeWatchonly(NullUniValue, wallet);
     }
 
-    if (options.exists("feeAsset")) {
-        std::string strFeeAsset = options["feeAsset"].get_str();
+    if (g_con_sequentiamode && options.exists("fee_asset")) {
+        std::string strFeeAsset = options["fee_asset"].get_str();
         CAsset feeAsset = GetAssetFromString(strFeeAsset);
         if (feeAsset.IsNull()) {
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Unknown label and invalid asset hex for fee: %s", feeAsset.GetHex()));
@@ -788,7 +788,7 @@ RPCHelpMan fundrawtransaction()
                             {"lockUnspents", RPCArg::Type::BOOL, RPCArg::Default{false}, "Lock selected unspent outputs"},
                             {"fee_rate", RPCArg::Type::AMOUNT, RPCArg::DefaultHint{"not set, fall back to wallet fee estimation"}, "Specify a fee rate in " + CURRENCY_ATOM + "/vB."},
                             {"feeRate", RPCArg::Type::AMOUNT, RPCArg::DefaultHint{"not set, fall back to wallet fee estimation"}, "Specify a fee rate in " + CURRENCY_UNIT + "/kvB."},
-                            {"feeAsset", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Hex asset id or asset label for fee payment."},
+                            {"fee_asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "The hex id or label of asset used for fee payment."},
                             {"subtractFeeFromOutputs", RPCArg::Type::ARR, RPCArg::Default{UniValue::VARR}, "The integers.\n"
                                                           "The fee will be equally deducted from the amount of each specified output.\n"
                                                           "Those recipients will receive less coins than you enter in their corresponding amount field.\n"

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -512,13 +512,12 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
             std::map<CAsset, CTxDestination> destinations;
 
             if (change_address.isStr()) {
-                // Single destination for default asset (policyAsset).
+                // Single destination for fee asset.
                 CTxDestination dest = DecodeDestination(change_address.get_str());
                 if (!IsValidDestination(dest)) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Change address must be a valid address");
                 }
-                // @SEQUENTIA
-                destinations[::policyAsset] = dest;
+                destinations[coinControl.m_fee_asset] = dest;
             } else if (change_address.isObject()) {
                 // Map of assets to destinations.
                 std::map<std::string, UniValue> kvMap;

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -370,10 +370,11 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
 static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter_ismine, const std::string* filter_label) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     CAmount nFee;
+    CAsset nFeeAsset;
     std::list<COutputEntry> listReceived;
     std::list<COutputEntry> listSent;
 
-    CachedTxGetAmounts(wallet, wtx, listReceived, listSent, nFee, filter_ismine);
+    CachedTxGetAmounts(wallet, wtx, listReceived, listSent, nFee, nFeeAsset, filter_ismine);
 
     bool involvesWatchonly = CachedTxIsFromMe(wallet, wtx, ISMINE_WATCH_ONLY);
 
@@ -400,6 +401,7 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
             }
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
+            entry.pushKV("feeasset", nFeeAsset.GetHex());
             if (fLong)
                 WalletTxToJSON(wallet, wtx, entry);
             entry.pushKV("abandoned", wtx.isAbandoned());
@@ -770,6 +772,7 @@ RPCHelpMan gettransaction()
                                 {RPCResult::Type::NUM, "vout", "the vout value"},
                                 {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the \n"
                                     "'send' category of transactions."},
+                                {RPCResult::Type::STR_AMOUNT, "feeasset", /*optional=*/true, "The label or hex id of the asset used for fee payment. This is only available in the 'send' category of transactions."},
                                 {RPCResult::Type::BOOL, "abandoned", /*optional=*/true, "'true' if the transaction has been abandoned (inputs are respendable). Only available for the \n"
                                      "'send' category of transactions."},
                             }},

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -515,6 +515,7 @@ RPCHelpMan listtransactions()
                             {RPCResult::Type::NUM, "vout", "the vout value"},
                             {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the\n"
                                  "'send' category of transactions."},
+                            {RPCResult::Type::STR_AMOUNT, "feeasset", /*optional=*/true, "The label or hex id of the asset used for fee payment. This is only available in the 'send' category of transactions."},
                         },
                         TransactionDescriptionString()),
                         {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -522,10 +522,10 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
     // So we need to include that for KnapsackSolver as well, as we are expecting to create a change output.
     CAmountMap mapTargetValue_copy = mapTargetValue;
     if (!coin_selection_params.m_subtract_fee_outputs) {
-        mapTargetValue_copy[::policyAsset] += coin_selection_params.m_change_fee;
+        mapTargetValue_copy[coin_selection_params.m_fee_asset] += coin_selection_params.m_change_fee;
     }
 
-    if (auto knapsack_result{KnapsackSolver(all_groups, mapTargetValue_copy)}) {
+    if (auto knapsack_result{KnapsackSolver(all_groups, mapTargetValue_copy, coin_selection_params.m_fee_asset)}) {
          knapsack_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
          results.push_back(*knapsack_result);
     }
@@ -653,10 +653,10 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
     const size_t max_descendants = (size_t)std::max<int64_t>(1, limit_descendant_count);
     const bool fRejectLongChains = gArgs.GetBoolArg("-walletrejectlongchains", DEFAULT_WALLET_REJECT_LONG_CHAINS);
 
-    // ELEMENTS: filter coins for assets we are interested in; always keep policyAsset for fees
+    // ELEMENTS: filter coins for assets we are interested in; always keep asset for fees
     for (std::vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coin_control.HasSelected();) {
         CAsset asset = it->GetInputCoin(wallet).asset;
-        if (asset != ::policyAsset && mapTargetValue.find(asset) == mapTargetValue.end()) {
+        if (asset != coin_selection_params.m_fee_asset && mapTargetValue.find(asset) == mapTargetValue.end()) {
             it = vCoins.erase(it);
         } else {
             ++it;
@@ -972,6 +972,7 @@ static bool CreateTransactionInternal(
             coin_selection_params.m_subtract_fee_outputs = true;
         }
     }
+    coin_selection_params.m_fee_asset = coin_selection_params.m_fee_asset.value();
 
     // Create change script that will be used if we need change
     // ELEMENTS: A map that keeps track of the change script for each asset and also
@@ -1140,7 +1141,7 @@ static bool CreateTransactionInternal(
             coin_selection_params.tx_noinputs_size += ::GetSerializeSize(txout, PROTOCOL_VERSION);
         }
 
-        if (recipient.asset == policyAsset && IsDust(txout, wallet.chain().relayDustFee()))
+        if (recipient.asset == coin_selection_params.m_fee_asset && IsDust(txout, wallet.chain().relayDustFee()))
         {
             error = _("Transaction amount too small");
             return false;
@@ -1193,7 +1194,7 @@ static bool CreateTransactionInternal(
     // Include the fees for things that aren't inputs, excluding the change output
     const CAmount not_input_fees = coin_selection_params.m_effective_feerate.GetFee(coin_selection_params.tx_noinputs_size);
     CAmountMap map_selection_target = map_recipients_sum;
-    map_selection_target[policyAsset] += not_input_fees;
+    map_selection_target[coin_selection_params.m_fee_asset] += not_input_fees;
 
     // Get available coins
     std::vector<COutput> vAvailableCoins;
@@ -1223,7 +1224,7 @@ static bool CreateTransactionInternal(
     CAmountMap map_change_and_fee = result->GetSelectedValue() - map_recipients_sum;
     // Zero out any non-policy assets which have zero change value
     for (auto it = map_change_and_fee.begin(); it != map_change_and_fee.end(); ) {
-        if (it->first != policyAsset && it->second == 0) {
+        if (it->first != coin_selection_params.m_fee_asset && it->second == 0) {
             it = map_change_and_fee.erase(it);
         } else {
             ++it;
@@ -1239,12 +1240,12 @@ static bool CreateTransactionInternal(
         error = _("Transaction change output index out of range");
         return false;
     } else {
-        change_pos[nChangePosInOut] = policyAsset;
+        change_pos[nChangePosInOut] = coin_selection_params.m_fee_asset;
     }
 
     for (const auto& asset_change_and_fee : map_change_and_fee) {
         // No need to randomly set the policyAsset change if has been set manually
-        if (nChangePosInOut >= 0 && asset_change_and_fee.first == policyAsset) {
+        if (nChangePosInOut >= 0 && asset_change_and_fee.first == coin_selection_params.m_fee_asset) {
             continue;
         }
 
@@ -1254,7 +1255,7 @@ static bool CreateTransactionInternal(
         } while (change_pos[index]);
 
         change_pos[index] = asset_change_and_fee.first;
-        if (asset_change_and_fee.first == policyAsset) {
+        if (asset_change_and_fee.first == coin_selection_params.m_fee_asset) {
             nChangePosInOut = index;
         }
     }
@@ -1294,7 +1295,7 @@ static bool CreateTransactionInternal(
                     blind_pub = wallet.GetBlindingPubKey(itScript->second.second);
                 }
             } else {
-                assert(asset == policyAsset);
+                assert(asset == coin_selection_params.m_fee_asset);
             }
 
             if (blind_pub) {
@@ -1316,7 +1317,7 @@ static bool CreateTransactionInternal(
 
     // Add fee output.
     if (g_con_elementsmode) {
-        CTxOut fee(::policyAsset, 0, CScript());
+        CTxOut fee(coin_selection_params.m_fee_asset, 0, CScript());
         assert(fee.IsFee());
         txNew.vout.push_back(fee);
         if (blind_details) {
@@ -1529,21 +1530,21 @@ static bool CreateTransactionInternal(
 
     // The only time that fee_needed should be less than the amount available for fees (in change_and_fee - change_amount) is when
     // we are subtracting the fee from the outputs. If this occurs at any other time, it is a bug.
-    if (!coin_selection_params.m_subtract_fee_outputs && fee_needed > map_change_and_fee.at(policyAsset) - change_amount) {
+    if (!coin_selection_params.m_subtract_fee_outputs && fee_needed > map_change_and_fee.at(coin_selection_params.m_fee_asset) - change_amount) {
         wallet.WalletLogPrintf("ERROR: not enough coins to cover for fee (needed: %d, total: %d, change: %d)\n",
-            fee_needed, map_change_and_fee.at(policyAsset), change_amount);
+            fee_needed, map_change_and_fee.at(coin_selection_params.m_fee_asset), change_amount);
         error = _("Could not cover fee");
         return false;
     }
 
     // Update nFeeRet in case fee_needed changed due to dropping the change output
-    if (fee_needed <= map_change_and_fee.at(policyAsset) - change_amount) {
-        nFeeRet = map_change_and_fee.at(policyAsset) - change_amount;
+    if (fee_needed <= map_change_and_fee.at(coin_selection_params.m_fee_asset) - change_amount) {
+        nFeeRet = map_change_and_fee.at(coin_selection_params.m_fee_asset) - change_amount;
     }
 
     // Reduce output values for subtractFeeFromAmount
     if (coin_selection_params.m_subtract_fee_outputs) {
-        CAmount to_reduce = fee_needed + change_amount - map_change_and_fee.at(policyAsset);
+        CAmount to_reduce = fee_needed + change_amount - map_change_and_fee.at(coin_selection_params.m_fee_asset);
         int i = 0;
         bool fFirst = true;
         for (const auto& recipient : vecSend)
@@ -1556,8 +1557,8 @@ static bool CreateTransactionInternal(
             if (recipient.fSubtractFeeFromAmount)
             {
                 CAmount value = txout.nValue.GetAmount();
-                if (recipient.asset != policyAsset) {
-                    error = Untranslated(strprintf("Wallet does not support more than one type of fee at a time, therefore can not subtract fee from address amount, which is of a different asset id. fee asset: %s recipient asset: %s", policyAsset.GetHex(), recipient.asset.GetHex()));
+                if (recipient.asset != coin_selection_params.m_fee_asset) {
+                    error = Untranslated(strprintf("Wallet does not support more than one type of fee at a time, therefore can not subtract fee from address amount, which is of a different asset id. fee asset: %s recipient asset: %s", coin_selection_params.m_fee_asset.GetHex(), recipient.asset.GetHex()));
                     return false;
                 }
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -939,11 +939,12 @@ static bool CreateTransactionInternal(
 
     CoinSelectionParams coin_selection_params; // Parameters for coin selection, init with dummy
     coin_selection_params.m_avoid_partial_spends = coin_control.m_avoid_partial_spends;
+    coin_selection_params.m_fee_asset = coin_control.m_fee_asset;
 
     CScript dummy_script = CScript() << 0x00;
     CAmountMap map_recipients_sum;
-    // Always assume that we are at least sending policyAsset.
-    map_recipients_sum[::policyAsset] = 0;
+    // Always assume that we are at least sending fee asset.
+    map_recipients_sum[coin_selection_params.m_fee_asset] = 0;
     std::vector<std::unique_ptr<ReserveDestination>> reservedest;
     // Set the long term feerate estimate to the wallet's consolidate feerate
     coin_selection_params.m_long_term_feerate = wallet.m_consolidate_feerate;
@@ -972,7 +973,6 @@ static bool CreateTransactionInternal(
             coin_selection_params.m_subtract_fee_outputs = true;
         }
     }
-    coin_selection_params.m_fee_asset = coin_selection_params.m_fee_asset.value();
 
     // Create change script that will be used if we need change
     // ELEMENTS: A map that keeps track of the change script for each asset and also


### PR DESCRIPTION
From the project statement:
> There should be no specific transaction fee currency on the sidechain. Thus, users would be able to propose sidechain transactions to Block Signers with the fee expressed as any amount of any asset issued on the sidechain. In the most common expected use cases, transaction fees on the sidechain would ideally be paid as a fraction of the same asset(s) being transferred on the sidechain. For example, one could have a Sequentia wallet containing only USDT, and use it to perform a p2p swap to acquire BTC. Only in the case of more volatile or less liquid assets (for which Block Signers might have no/insufficient demand), would a user possibly need a second sidechain asset in their wallet in order to pay fees.

## Features
Done:
- Add global sequentia flag for enabling sequentia features
- Support fee payment with any asset in manually constructed transactions (`createrawtransaction` RPC)
- Support fee payment with any asset in coin selection algorithm (used by `fundrawtransaction`, and `sendtoaddress`)
- Reward transaction fees in any asset in coinbase 
- Add RPCs for getting and setting asset exchange rates (`getfeeexchangerates` and `setfeeexchangerates` in new `exchangerates` category)
- Update transaction RPCs to include information about fee asset (`gettransaction`, `listtransactions`)
- Config file for whitelisting and valuation of assets used in fee payments

Done, but needs testing:
- Recompute mempool entries whenever asset exchange rates are updated

To do:
- Asset-aware fee estimation 


## RPC breakdown

### raw transactions
- [x] `createrawtransaction`
- [x] `fundrawtransaction`
- [ ] `testmempoolaccept`

### wallet
- [x] `gettransaction`
- [x] `listtransactions` 
- [x] `sendtoaddress`

### exchange rates
- [x] `getfeexchangerates`
- [x] `setfeeexchangerates`